### PR TITLE
Fixed Readthedocs config

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -25,3 +25,6 @@ python:
     - requirements: requirements.txt
     - requirements: requirements_dev.txt
     - method: pip
+      path: .
+      extra_requirements:
+        - dev

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,27 @@
+# .readthedocs.yml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Build documentation in the docs/ directory with Sphinx
+sphinx:
+  builder: html
+  configuration: docs/apiref/conf.py
+
+# Build documentation with MkDocs
+#mkdocs:
+#  configuration: mkdocs.yml
+
+# Optionally build your docs in additional formats such as PDF
+formats:
+  - pdf
+
+# Optionally set the version of Python and requirements required to build your docs
+python:
+  version: 3.7
+  install:
+    - requirements: requirements.txt
+    - requirements: requirements_dev.txt
+    - method: pip

--- a/docs/apiref/conf.py
+++ b/docs/apiref/conf.py
@@ -62,6 +62,7 @@ html_theme = 'alabaster'
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
 html_static_path = ['_static']
+master_doc = 'index'
 
 
 # -- Extension configuration -------------------------------------------------

--- a/docs/apiref/index.rst
+++ b/docs/apiref/index.rst
@@ -1,0 +1,21 @@
+.. xyzspaces documentation master file, created by
+   sphinx-quickstart on Thu Jul 23 23:00:10 2020.
+   You can adapt this file completely to your liking, but it should at least
+   contain the root `toctree` directive.
+
+Welcome to xyzspaces's documentation!
+=====================================
+
+.. toctree::
+   :maxdepth: 4
+   :caption: Contents:
+
+   xyzspaces
+
+
+Indices and tables
+==================
+
+* :ref:`genindex`
+* :ref:`modindex`
+* :ref:`search`

--- a/docs/apiref/xyzspaces.apis.rst
+++ b/docs/apiref/xyzspaces.apis.rst
@@ -1,0 +1,8 @@
+xyzspaces.apis module
+=====================
+
+.. automodule:: xyzspaces.apis
+   :members:
+   :undoc-members:
+   :show-inheritance:
+   :private-members:

--- a/docs/apiref/xyzspaces.auth.rst
+++ b/docs/apiref/xyzspaces.auth.rst
@@ -1,0 +1,8 @@
+xyzspaces.auth module
+=====================
+
+.. automodule:: xyzspaces.auth
+   :members:
+   :undoc-members:
+   :show-inheritance:
+   :private-members:

--- a/docs/apiref/xyzspaces.curl.rst
+++ b/docs/apiref/xyzspaces.curl.rst
@@ -1,0 +1,8 @@
+xyzspaces.curl module
+=====================
+
+.. automodule:: xyzspaces.curl
+   :members:
+   :undoc-members:
+   :show-inheritance:
+   :private-members:

--- a/docs/apiref/xyzspaces.datasets.rst
+++ b/docs/apiref/xyzspaces.datasets.rst
@@ -1,0 +1,8 @@
+xyzspaces.datasets package
+==========================
+
+.. automodule:: xyzspaces.datasets
+   :members:
+   :undoc-members:
+   :show-inheritance:
+   :private-members:

--- a/docs/apiref/xyzspaces.exceptions.rst
+++ b/docs/apiref/xyzspaces.exceptions.rst
@@ -1,0 +1,8 @@
+xyzspaces.exceptions module
+===========================
+
+.. automodule:: xyzspaces.exceptions
+   :members:
+   :undoc-members:
+   :show-inheritance:
+   :private-members:

--- a/docs/apiref/xyzspaces.logconf.rst
+++ b/docs/apiref/xyzspaces.logconf.rst
@@ -1,0 +1,8 @@
+xyzspaces.logconf module
+========================
+
+.. automodule:: xyzspaces.logconf
+   :members:
+   :undoc-members:
+   :show-inheritance:
+   :private-members:

--- a/docs/apiref/xyzspaces.rst
+++ b/docs/apiref/xyzspaces.rst
@@ -1,0 +1,31 @@
+xyzspaces package
+=================
+
+.. automodule:: xyzspaces
+   :members:
+   :undoc-members:
+   :show-inheritance:
+   :private-members:
+
+Subpackages
+-----------
+
+.. toctree::
+   :maxdepth: 4
+
+   xyzspaces.datasets
+
+Submodules
+----------
+
+.. toctree::
+   :maxdepth: 4
+
+   xyzspaces.apis
+   xyzspaces.auth
+   xyzspaces.curl
+   xyzspaces.exceptions
+   xyzspaces.logconf
+   xyzspaces.spaces
+   xyzspaces.tools
+   xyzspaces.utils

--- a/docs/apiref/xyzspaces.spaces.rst
+++ b/docs/apiref/xyzspaces.spaces.rst
@@ -1,0 +1,8 @@
+xyzspaces.spaces module
+=======================
+
+.. automodule:: xyzspaces.spaces
+   :members:
+   :undoc-members:
+   :show-inheritance:
+   :private-members:

--- a/docs/apiref/xyzspaces.tools.rst
+++ b/docs/apiref/xyzspaces.tools.rst
@@ -1,0 +1,8 @@
+xyzspaces.tools module
+======================
+
+.. automodule:: xyzspaces.tools
+   :members:
+   :undoc-members:
+   :show-inheritance:
+   :private-members:

--- a/docs/apiref/xyzspaces.utils.rst
+++ b/docs/apiref/xyzspaces.utils.rst
@@ -1,0 +1,8 @@
+xyzspaces.utils module
+======================
+
+.. automodule:: xyzspaces.utils
+   :members:
+   :undoc-members:
+   :show-inheritance:
+   :private-members:

--- a/scripts/build_apiref.sh
+++ b/scripts/build_apiref.sh
@@ -28,5 +28,5 @@ rm -rf $DEST/_templates
 
 # Just creating conf.py, Makefile and make.bat once, hence commenting below.
 
-sphinx-apidoc --private --separate --module-first --full -o $DEST xyz
+sphinx-apidoc --private --separate --module-first --full -o $DEST xyzspaces
 sphinx-build -b html -D html_theme=sphinx_rtd_theme $DEST $DEST/_build/html


### PR DESCRIPTION
This PR fixes the following issues: 
1. Added .readthedocs.yml config file so that it builds with the correct version.
2. fixed build script.
3. Added all .rst files so that Readthedocs builds passes.

I have tested this on my forked repo.
test docs link: https://xyz-spaces-python-test.readthedocs.io/en/latest/index.html