### PR TITLE
Added clientId in query params for Hub API requests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ _build/
 .venv
 .vscode
 .debug.env
+xyz.log

--- a/tests/hub/test_api.py
+++ b/tests/hub/test_api.py
@@ -85,8 +85,8 @@ def test_round_trip(api):
     api.put_space_features(
         space_id=space_id,
         data=gj_countries,
-        addTags=["foo", "bar"],
-        removeTags=["bar"],
+        add_tags=["foo", "bar"],
+        remove_tags=["bar"],
     )
 
     # get one feature
@@ -107,7 +107,7 @@ def test_round_trip1(api):
 
     # add features
     api.put_space_features(
-        space_id=space_id, data=gj_countries, addTags=["foo", "bar"]
+        space_id=space_id, data=gj_countries, add_tags=["foo", "bar"]
     )
 
     # delete one features with given tag
@@ -137,11 +137,11 @@ def test_round_trip2(api, space_id):
         space_id=space_id,
         feature_id=feature_id,
         data=fra,
-        addTags=["foo", "bar"],
+        add_tags=["foo", "bar"],
     )
 
     api.patch_space_feature(
-        space_id=space_id, feature_id=feature_id, data=fra, removeTags=["bar"]
+        space_id=space_id, feature_id=feature_id, data=fra, remove_tags=["bar"]
     )
 
     # get two features

--- a/tests/space/conftest.py
+++ b/tests/space/conftest.py
@@ -112,3 +112,32 @@ def shared_space():
 
     # now teardown (delete temporary space)
     space.delete()
+
+
+@pytest.fixture()
+def activity_log_space():
+    """Create a new space supporting activity log."""
+    listeners = {
+        "id": "activity-log",
+        "params": {
+            "states": 5,
+            "storageMode": "DIFF_ONLY",
+            "writeInvalidatedAt": "true",
+        },
+        "eventTypes": ["ModifySpaceEvent.request"],
+    }
+    space = Space.new(
+        title="Activity-Log Test",
+        description="A test space for Activity-Log",
+        enable_uuid=True,
+        listeners=listeners,
+    )
+    yield space
+
+    # now teardown (delete temporary space and activity log space)
+    activity_log_spaceid = space.info["listeners"]["activity-log-writer"][0][
+        "params"
+    ]["spaceId"]
+    space2 = Space.from_id(activity_log_spaceid)
+    space.delete()
+    space2.delete()

--- a/tests/space/test_space_objects.py
+++ b/tests/space/test_space_objects.py
@@ -525,25 +525,10 @@ def test_schema_validation(space_object):
 
 
 @pytest.mark.skipif(not XYZ_TOKEN, reason="No token found.")
-def test_activity_log():
+def test_activity_log(activity_log_space):
     """Test activity log."""
 
-    listeners = {
-        "id": "activity-log",
-        "params": {
-            "states": 5,
-            "storageMode": "DIFF_ONLY",
-            "writeInvalidatedAt": "true",
-        },
-        "eventTypes": ["ModifySpaceEvent.request"],
-    }
-    space = Space.new(
-        title="Activity-Log Test",
-        description="A test space for Activity-Log",
-        enable_uuid=True,
-        listeners=listeners,
-    )
-    space_id = space.info["id"]
+    space = activity_log_space
     # Adding some sleep as activity log is async activity
     sleep(5)
     space_info = space.info
@@ -551,12 +536,6 @@ def test_activity_log():
     assert type(params["params"]["spaceId"]) == str
     assert params["params"]["storageMode"] == "DIFF_ONLY"
     assert params["params"]["writeInvalidatedAt"] is True
-
-    # clean up
-    space.delete()
-    assert space.info == {}
-    with pytest.raises(ApiError):
-        space.read(id=space_id)
 
 
 @pytest.mark.skipif(not XYZ_TOKEN, reason="No token found.")

--- a/xyzspaces/apis.py
+++ b/xyzspaces/apis.py
@@ -40,6 +40,8 @@ from .utils import join_string_lists
 
 logger = logging.getLogger(__name__)
 
+_CLIENT_ID = "dhpy"
+
 
 class Api:
     """A low-level HTTP RESTful API client.
@@ -440,6 +442,7 @@ class HubApi(Api):
         :param params: A dict holding the HTTP query parameters.
         :return: A JSON object with hub information.
         """
+        params.update({"clientId": _CLIENT_ID})
         return self.get(path="/hub", params=params).json()
 
     # Read Spaces
@@ -450,6 +453,7 @@ class HubApi(Api):
         :param params: A dict holding the HTTP query parameters.
         :return: A JSON object with list of spaces.
         """
+        params.update({"clientId": _CLIENT_ID})
         return self.get(path="/hub/spaces", params=params).json()
 
     def get_space(self, space_id: str, params: dict = {}) -> dict:
@@ -460,6 +464,7 @@ class HubApi(Api):
         :return: A JSON object with information about the space_id.
         """
         path = f"/hub/spaces/{space_id}"
+        params.update({"clientId": _CLIENT_ID})
         return self.get(path=path, params=params).json()
 
     # Edit Spaces
@@ -470,7 +475,8 @@ class HubApi(Api):
         :param data: A dict describing the space to be created.
         :return: A JSON object with all information about the created space.
         """
-        return self.post(path="/hub/spaces", json=data).json()
+        params = {"clientId": _CLIENT_ID}
+        return self.post(path="/hub/spaces", json=data, params=params).json()
 
     def patch_space(self, space_id: str, data: dict) -> dict:
         """Update a space.
@@ -480,7 +486,8 @@ class HubApi(Api):
         :return: A JSON object with information about the updated space.
         """
         path = f"/hub/spaces/{space_id}"
-        return self.patch(path=path, json=data).json()
+        params = {"clientId": _CLIENT_ID}
+        return self.patch(path=path, json=data, params=params).json()
 
     def delete_space(self, space_id: str) -> str:
         """Delete a space.
@@ -489,7 +496,8 @@ class HubApi(Api):
         :return: An empty string if the operation was successful.
         """
         path = f"/hub/spaces/{space_id}"
-        return self.delete(path=path).text
+        params = {"clientId": _CLIENT_ID}
+        return self.delete(path=path, params=params).text
 
     # Read Features
 
@@ -510,7 +518,7 @@ class HubApi(Api):
         >>> print(feats)
         """
         path = f"/hub/spaces/{space_id}/features"
-        params = {"id": feature_ids}
+        params = {"id": feature_ids, "clientId": _CLIENT_ID}
         return self.get(path=path, params=params).json()
 
     def get_space_feature(self, space_id: str, feature_id: str) -> dict:
@@ -528,7 +536,8 @@ class HubApi(Api):
         >>>	print(json.dumps(feature, indent=4, sort_keys=True))
         """
         path = f"/hub/spaces/{space_id}/features/{feature_id}"
-        return self.get(path=path).json()
+        params = {"clientId": _CLIENT_ID}
+        return self.get(path=path, params=params).json()
 
     def get_space_statistics(self, space_id: str) -> dict:
         """Get statistics.
@@ -542,7 +551,8 @@ class HubApi(Api):
         >>>	print(json.dumps(stats, indent=4, sort_keys=True))
         """
         path = f"/hub/spaces/{space_id}/statistics"
-        return self.get(path=path).json()
+        params = {"clientId": _CLIENT_ID}
+        return self.get(path=path, params=params).json()
 
     def get_space_bbox(
         self,
@@ -585,6 +595,7 @@ class HubApi(Api):
         q_params: Dict[str, str] = dict(
             west=str(w), south=str(s), east=str(e), north=str(n)
         )
+        q_params.update({"clientId": _CLIENT_ID})
         if tags:
             q_params["tags"] = ",".join(tags)
         if clip:
@@ -654,7 +665,7 @@ class HubApi(Api):
         - here, ?
         """
         path = f"/hub/spaces/{space_id}/tile/{tile_type}/{tile_id}"
-        q_params: Dict[str, str] = {}
+        q_params: Dict[str, str] = {"clientId": _CLIENT_ID}
         if tags:
             q_params["tags"] = ",".join(tags)
         if clip:
@@ -707,7 +718,7 @@ class HubApi(Api):
         >>>	print(feats["type"] )
         >>>	print(len(feats["features"]) )
         """
-        q_params: Dict[str, str] = {}
+        q_params: Dict[str, str] = {"clientId": _CLIENT_ID}
         if tags:
             q_params["tags"] = ",".join(tags)
         if limit:
@@ -730,7 +741,7 @@ class HubApi(Api):
         :yields: A feature in space.
         """
         path = f"/hub/spaces/{space_id}/iterate"
-        params = {"limit": limit}
+        params = {"limit": limit, "clientId": _CLIENT_ID}
         while True:
             res: dict = self.get(path=path, params=params).json()
             handle = res.get("handle", None)
@@ -772,7 +783,8 @@ class HubApi(Api):
             space.
         """
         path = f"/hub/spaces/{space_id}/count"
-        return self.get(path=path).json()
+        params = {"clientId": _CLIENT_ID}
+        return self.get(path=path, params=params).json()
 
     # Edit Features
 
@@ -780,16 +792,16 @@ class HubApi(Api):
         self,
         space_id: str,
         data: dict,
-        addTags: Optional[List[str]] = None,
-        removeTags: Optional[List[str]] = None,
+        add_tags: Optional[List[str]] = None,
+        remove_tags: Optional[List[str]] = None,
     ) -> dict:
         """Create or replace multiple features.
 
         :param space_id: A string with the ID of the desired XYZ space.
         :param data: A JSON object describing one or more features to add.
-        :param addTags: A list of strings describing tags to be added to
+        :param add_tags: A list of strings describing tags to be added to
             the features.
-        :param removeTags: A list of strings describing tags to be removed
+        :param remove_tags: A list of strings describing tags to be removed
             from the features.
         :return: A dict representing a feature collection.
 
@@ -800,15 +812,16 @@ class HubApi(Api):
         >>>	features = api.put_space_features(
         ...     space_id=space_id,
         ...     data=gj_countries,
-        ...     addTags=["foo", "bar"],
-        ...     removeTags=["bar"],
+        ...     add_tags=["foo", "bar"],
+        ...     remove_tags=["bar"],
         ... )
         >>> print(features)
         """
         path = f"/hub/spaces/{space_id}/features"
         headers = dict(self.headers)
         headers["Content-Type"] = "application/geo+json"
-        params = join_string_lists(addTags=addTags, removeTags=removeTags)
+        params = join_string_lists(addTags=add_tags, removeTags=remove_tags)
+        params.update({"clientId": _CLIENT_ID})
         return self.put(
             path=path, params=params, json=data, headers=headers
         ).json()
@@ -817,17 +830,17 @@ class HubApi(Api):
         self,
         space_id: str,
         data: dict,  # must be a feature collection
-        addTags: Optional[List[str]] = None,
-        removeTags: Optional[List[str]] = None,
+        add_tags: Optional[List[str]] = None,
+        remove_tags: Optional[List[str]] = None,
     ) -> dict:
         """Modify multiple features in the space.
 
         :param space_id: A string with the ID of the desired XYZ space.
         :param data: A JSON object describing one or more features to
             modify.
-        :param addTags: A list of strings describing tags to be added to
+        :param add_tags: A list of strings describing tags to be added to
             the features.
-        :param removeTags: A list of strings describing tags to be removed
+        :param remove_tags: A list of strings describing tags to be removed
             from the features.
         :return: A dict representing a feature collection.
 
@@ -841,7 +854,8 @@ class HubApi(Api):
         path = f"/hub/spaces/{space_id}/features"
         headers = dict(self.headers)
         headers["Content-Type"] = "application/geo+json"
-        params = join_string_lists(addTags=addTags, removeTags=removeTags)
+        params = join_string_lists(addTags=add_tags, removeTags=remove_tags)
+        params.update({"clientId": _CLIENT_ID})
         return self.post(
             path=path, params=params, json=data, headers=headers
         ).json()
@@ -870,7 +884,7 @@ class HubApi(Api):
         path = f"/hub/spaces/{space_id}/features"
         headers = dict(self.headers)
         headers["Content-Type"] = "application/geo+json"
-        params = {}
+        params = {"clientId": _CLIENT_ID}
         if id:
             # TODO: The wildcard sign(*) could be used to delete all features
             #       in the space.
@@ -884,17 +898,17 @@ class HubApi(Api):
         space_id: str,
         data: dict,
         feature_id: Optional[str] = None,
-        addTags: Optional[List[str]] = None,
-        removeTags: Optional[List[str]] = None,
+        add_tags: Optional[List[str]] = None,
+        remove_tags: Optional[List[str]] = None,
     ) -> dict:
         """Create or replace a single feature.
 
         :param space_id: A string with the ID of the desired XYZ space.
         :param data: A JSON object describing the feature to be added.
         :param feature_id: A string with the ID of the feature to be created.
-        :param addTags: A list of strings describing tags to be added to
+        :param add_tags: A list of strings describing tags to be added to
             the feature.
-        :param removeTags: A list of strings describing tags to be removed
+        :param remove_tags: A list of strings describing tags to be removed
             from the feature.
         :return: A dict representing a feature.
 
@@ -909,7 +923,8 @@ class HubApi(Api):
             path = f"/hub/spaces/{space_id}/features/"
         headers = dict(self.headers)
         headers["Content-Type"] = "application/geo+json"
-        params = join_string_lists(addTags=addTags, removeTags=removeTags)
+        params = join_string_lists(addTags=add_tags, removeTags=remove_tags)
+        params.update({"clientId": _CLIENT_ID})
         return self.put(
             path=path, params=params, json=data, headers=headers
         ).json()
@@ -919,24 +934,25 @@ class HubApi(Api):
         space_id: str,
         feature_id: str,
         data: dict,
-        addTags: Optional[List[str]] = None,
-        removeTags: Optional[List[str]] = None,
+        add_tags: Optional[List[str]] = None,
+        remove_tags: Optional[List[str]] = None,
     ) -> dict:
         """Patch a single feature in the space.
 
         :param space_id: A string with the ID of the desired XYZ space.
         :param feature_id: A string with the ID of the feature to be modified.
         :param data: A JSON object describing the feature to be changed.
-        :param addTags: A list of strings describing tags to be added to
+        :param add_tags: A list of strings describing tags to be added to
             the feature.
-        :param removeTags: A list of strings describing tags to be removed
+        :param remove_tags: A list of strings describing tags to be removed
             from the feature.
         :return: A dict representing a feature.
         """
         path = f"/hub/spaces/{space_id}/features/{feature_id}"
         headers = dict(self.headers)
         headers["Content-Type"] = "application/geo+json"
-        params = join_string_lists(addTags=addTags, removeTags=removeTags)
+        params = join_string_lists(addTags=add_tags, removeTags=remove_tags)
+        params.update({"clientId": _CLIENT_ID})
         return self.patch(
             path=path, params=params, json=data, headers=headers
         ).json()
@@ -949,7 +965,8 @@ class HubApi(Api):
         :return: An empty string if the operation was successful.
         """
         path = f"/hub/spaces/{space_id}/features/{feature_id}"
-        return self.delete(path=path).text
+        params = {"clientId": _CLIENT_ID}
+        return self.delete(path=path, params=params).text
 
     def get_space_spatial(
         self,
@@ -997,7 +1014,7 @@ class HubApi(Api):
                 "or ref_space_id and ref_feature_id should have value."
             )
         path = f"/hub/spaces/{space_id}/spatial"
-        q_params: Dict[str, str] = {}
+        q_params: Dict[str, str] = {"clientId": _CLIENT_ID}
         if lat:
             q_params["lat"] = str(lat)
         if lon:
@@ -1048,7 +1065,7 @@ class HubApi(Api):
         headers = dict(self.headers)
         headers["Content-Type"] = "application/geo+json"
 
-        q_params: Dict[str, str] = {}
+        q_params: Dict[str, str] = {"clientId": _CLIENT_ID}
         if radius:
             q_params["radius"] = str(radius)
         if tags:

--- a/xyzspaces/spaces.py
+++ b/xyzspaces/spaces.py
@@ -325,8 +325,8 @@ class Space:
             space_id=self._info["id"],
             feature_id=feature_id,
             data=data,
-            addTags=add_tags,
-            removeTags=remove_tags,
+            add_tags=add_tags,
+            remove_tags=remove_tags,
         )
         return GeoJSON(res)
 
@@ -352,8 +352,8 @@ class Space:
             space_id=self._info["id"],
             feature_id=feature_id,
             data=data,
-            addTags=add_tags,
-            removeTags=remove_tags,
+            add_tags=add_tags,
+            remove_tags=remove_tags,
         )
         return GeoJSON(res)
 
@@ -429,8 +429,8 @@ class Space:
             res = self.api.put_space_features(
                 space_id=space_id,
                 data=features,
-                addTags=add_tags,
-                removeTags=remove_tags,
+                add_tags=add_tags,
+                remove_tags=remove_tags,
             )
             return GeoJSON(res)
 
@@ -445,8 +445,8 @@ class Space:
         self.api.put_space_features(
             space_id=self._info["id"],
             data=feature_collection,
-            addTags=add_tags,
-            removeTags=remove_tags,
+            add_tags=add_tags,
+            remove_tags=remove_tags,
         )
         return len(features)
 
@@ -471,8 +471,8 @@ class Space:
         res = self.api.post_space_features(
             space_id=space_id,
             data=features,
-            addTags=add_tags,
-            removeTags=remove_tags,
+            add_tags=add_tags,
+            remove_tags=remove_tags,
         )
         return GeoJSON(res)
 


### PR DESCRIPTION
Signed-off-by: Kharude, Sachin <sachin.kharude@here.com>

 - Added `clientId` in query params as suggested by DataHub developers this helps in identifying requests sent from `xyzspaces` library.
 - Minor variable name changes as per pep8 guidelines.
 - Improved clean up for activity log test.
