### PR TITLE
reverted pin for pytest version

### DIFF
--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -5,7 +5,7 @@ black==19.10b0
 mypy
 proclamation
 proxy.py
-pytest>=5.4.3,<=6.0.2 # https://github.com/pytest-dev/pytest-rerunfailures/issues/128
+pytest>=5.4.3
 pytest-cov
 pytest-mypy
 pytest-rerunfailures


### PR DESCRIPTION
Signed-off-by: Kharude, Sachin <sachin.kharude@here.com>
Revereted version pin for pytest as, issue is fixed for pytest-rerunfailures - https://github.com/pytest-dev/pytest-rerunfailures/pull/129 