### PR TITLE
Fix: added mode and viz_sampling params in space class method features_in_tile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ _build/
 .debug.env
 xyz.log
 .coverage.*
+xyzspaces.egg-info/

--- a/changes/features/pr.96.md
+++ b/changes/features/pr.96.md
@@ -1,0 +1,1 @@
+support the new `force2D` parameter for all the APIs used to read features.

--- a/tests/space/test_space_objects.py
+++ b/tests/space/test_space_objects.py
@@ -27,6 +27,7 @@ from geojson import GeoJSON
 
 from xyzspaces import XYZ
 from xyzspaces.datasets import (
+    MICROSOFT_BUILDINGS_SPACE_ID,
     get_chicago_parks_data,
     get_countries_data,
     get_microsoft_buildings_space,
@@ -848,3 +849,30 @@ def test_force_2d(space_object):
     )
     features = list(res)
     assert len(features[0]["geometry"]["coordinates"][0][0]) == 2
+
+
+@pytest.mark.skipif(not XYZ_TOKEN, reason="No token found.")
+def test_get_space_tile_sampling(api):
+    """Get space tile and compare all available sampling rates."""
+    space = Space.from_id(MICROSOFT_BUILDINGS_SPACE_ID)
+    params = dict(tile_type="web", tile_id="11_585_783",)
+    tile_raw = list(space.features_in_tile(mode="raw", **params))
+    tile_viz_off = list(
+        space.features_in_tile(mode="viz", viz_sampling="off", **params)
+    )
+    tile_viz_low = list(
+        space.features_in_tile(mode="viz", viz_sampling="low", **params)
+    )
+    tile_viz_med = list(
+        space.features_in_tile(mode="viz", viz_sampling="med", **params)
+    )
+    tile_viz_high = list(
+        space.features_in_tile(mode="viz", viz_sampling="high", **params)
+    )
+
+    len_raw = len(tile_raw)
+    len_viz_off = len(tile_viz_off)
+    len_viz_low = len(tile_viz_low)
+    len_viz_med = len(tile_viz_med)
+    len_viz_high = len(tile_viz_high)
+    assert len_raw > len_viz_off > len_viz_low > len_viz_med >= len_viz_high

--- a/xyzspaces/spaces.py
+++ b/xyzspaces/spaces.py
@@ -726,6 +726,8 @@ class Space:
         limit: Optional[int] = None,
         geo_dataframe: Optional[bool] = None,
         force_2d: Optional[bool] = None,
+        mode: Optional[str] = None,
+        viz_sampling: Optional[str] = None,
     ) -> Generator[Feature, None, None]:
         """
         Get features in tile.
@@ -772,6 +774,11 @@ class Space:
         :param force_2d: If set to True the features in the response
             will have only X and Y components, by default all
             x,y,z coordinates will be returned.
+        :param mode: A string to indicate how to optimize the resultset and
+            geometries for display. Allowed values are ``raw`` and ``viz``.
+        :param viz_sampling: A string to indicate the sampling strength in
+            case of ``mode=viz``. Allowed values are: ``low``, ``med``,
+            ``high``, and ``off``, default: ``med``.
         :raises ValueError: If `tile_type` is invalid, valid tile_types are
              `quadkeys`, `web`, `tms` and `here`.
         """
@@ -790,6 +797,8 @@ class Space:
                 margin=margin,
                 limit=limit,
                 force_2d=force_2d,
+                mode=mode,
+                viz_sampling=viz_sampling,
             )
             if geo_dataframe is not None:
                 yield gpd.GeoDataFrame.from_features(


### PR DESCRIPTION
This PR fixes two missing parameters in the `Space` class's method `features_in_tile`,  `mode` and `viz_sampling` which were present in the Api class's method `get_space_tile`.
Also added missing proclamation changes.