### PR TITLE
Fix for feature id getting skipped from Geopandas Dataframe result

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@ _build/
 xyz.log
 .coverage.*
 xyzspaces.egg-info/
+build/
+dist/

--- a/tests/space/test_space_objects.py
+++ b/tests/space/test_space_objects.py
@@ -202,7 +202,7 @@ def test_space_features_search_operations(space_object):
     gdf = next(
         space_object.features_in_bbox(bbox=[0, 0, 20, 20], geo_dataframe=True)
     )
-    assert gdf.shape == (15, 3)
+    assert gdf.shape == (15, 4)
 
     spatial_search = list(
         space_object.spatial_search(
@@ -217,7 +217,7 @@ def test_space_features_search_operations(space_object):
             lat=37.377228699000057, lon=74.512691691000043, geo_dataframe=True
         )
     )
-    assert ss_gdf.shape == (1, 3)
+    assert ss_gdf.shape == (1, 4)
 
     data1 = {"type": "Point", "coordinates": [72.8557, 19.1526]}
     spatial_search_geom = list(
@@ -228,14 +228,14 @@ def test_space_features_search_operations(space_object):
     ss_gdf = next(
         space_object.spatial_search_geometry(data=data1, geo_dataframe=True)
     )
-    assert ss_gdf.shape == (1, 3)
+    assert ss_gdf.shape == (1, 4)
     with pytest.raises(ValueError):
         list(space_object.features_in_tile(tile_type="dummy", tile_id="12"))
     res = space_object.features_in_tile(
         tile_type="here", tile_id="12", limit=10, geo_dataframe=True
     )
     gdf = next(res)
-    assert gdf.shape == (10, 3)
+    assert gdf.shape == (10, 4)
     res = space_object.features_in_tile(
         tile_type="here", tile_id="12", limit=10
     )

--- a/xyzspaces/spaces.py
+++ b/xyzspaces/spaces.py
@@ -28,6 +28,7 @@ dictionaries, like the "statistics" of some given XYZ space.
 import concurrent.futures
 import copy
 import hashlib
+import io
 import json
 import logging
 import os
@@ -341,8 +342,9 @@ class Space:
             skip_cache=skip_cache,
             force_2d=force_2d,
         )
-        if geo_dataframe is not None:
-            yield gpd.GeoDataFrame.from_features(features=features["features"])
+        if geo_dataframe is True:
+            fbytes = json.dumps(features).encode("utf-8")
+            yield gpd.read_file(io.BytesIO(fbytes))
         for f in features["features"]:
             yield f
 
@@ -470,8 +472,9 @@ class Space:
             feature_ids=feature_ids,
             force_2d=force_2d,
         )
-        if geo_dataframe is not None:
-            return gpd.GeoDataFrame.from_features(features=res["features"])
+        if geo_dataframe is True:
+            fbytes = json.dumps(res).encode("utf-8")
+            return gpd.read_file(io.BytesIO(fbytes))
         return GeoJSON(res)
 
     def add_features(
@@ -724,8 +727,9 @@ class Space:
             force_2d=force_2d,
         )
 
-        if geo_dataframe is not None:
-            yield gpd.GeoDataFrame.from_features(features=features["features"])
+        if geo_dataframe is True:
+            fbytes = json.dumps(features).encode("utf-8")
+            yield gpd.read_file(io.BytesIO(fbytes))
         else:
             for f in features["features"]:
                 yield f
@@ -819,10 +823,9 @@ class Space:
                 mode=mode,
                 viz_sampling=viz_sampling,
             )
-            if geo_dataframe is not None:
-                yield gpd.GeoDataFrame.from_features(
-                    features=features["features"]
-                )
+            if geo_dataframe is True:
+                fbytes = json.dumps(features).encode("utf-8")
+                yield gpd.read_file(io.BytesIO(fbytes))
             else:
                 for f in features["features"]:
                     yield f
@@ -905,8 +908,9 @@ class Space:
             skip_cache=skip_cache,
             force_2d=force_2d,
         )
-        if geo_dataframe is not None:
-            yield gpd.GeoDataFrame.from_features(features=features["features"])
+        if geo_dataframe is True:
+            fbytes = json.dumps(features).encode("utf-8")
+            yield gpd.read_file(io.BytesIO(fbytes))
         else:
             for f in features["features"]:
                 yield f
@@ -985,10 +989,9 @@ class Space:
                 skip_cache=skip_cache,
                 force_2d=force_2d,
             )
-            if geo_dataframe is not None:
-                yield gpd.GeoDataFrame.from_features(
-                    features=features["features"]
-                )
+            if geo_dataframe is True:
+                fbytes = json.dumps(features).encode("utf-8")
+                yield gpd.read_file(io.BytesIO(fbytes))
             else:
                 for f in features["features"]:
                     yield f
@@ -1024,8 +1027,9 @@ class Space:
                 each["id"]: each for each in feature_list
             }.values()
 
-            if geo_dataframe is not None:
-                yield gpd.GeoDataFrame.from_features(features=unique_features)
+            if geo_dataframe is True:
+                fbytes = json.dumps(unique_features).encode("utf-8")
+                yield gpd.read_file(io.BytesIO(fbytes))
             else:
                 for f in unique_features:
                     yield f


### PR DESCRIPTION
Signed-off-by: Kharude, Sachin <sachin.kharude@here.com>.

Currently when data from space is returned as geopandas dataframe feature id is getting skipped from result due to https://github.com/geopandas/geopandas/issues/1208. This PR fixes this issue by using `geopandas.read_file` method rather than using `geopandas.read_features`.