### PR TITLE
removed pandas from dependency and made geobuf optional

### DIFF
--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -2,7 +2,7 @@ Installation
 ============
 
 xyzspaces has optional dependencies for its spatial functionality on a large geospatial, open
-source stack of libraries (`Geopandas`_, `turfpy`_). See the
+source stack of libraries (`Geopandas`_, `turfpy`_, `geobuf`_). See the
 :ref:`dependencies` section below for more details. The C depedencies of Geopandas such as (`GEOS`_, `GDAL`_, `PROJ`_)
 can sometimes be a challenge to install. Therefore, we advise you
 to closely follow the recommendations below to avoid installation problems.
@@ -116,6 +116,7 @@ Optional depedencies:
 
 - `Geopandas`_
 - `turfpy`_
+- `geobuf`_
 
 Dev dependencies:
 
@@ -156,4 +157,6 @@ Dev dependencies:
 .. _GEOS: https://geos.osgeo.org
 
 .. _PROJ: https://proj.org/
+
+.. _geobuf: https://pypi.org/project/geobuf/
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,8 +2,6 @@
 backoff>=1.10.0
 geojson
 requests
-geobuf
 ijson>=3.1.1
 pyhocon
 requests-oauthlib
-pandas

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ with open(path.join(here, "requirements_dev.txt"), encoding="utf-8") as f:
 
 # Extra dependencies
 
-geo = ["geopandas", "turfpy>=0.0.3"]
+geo = ["geopandas", "turfpy>=0.0.3", "geobuf"]
 
 extras_require = {"dev": dev_reqs, "geo": geo}
 


### PR DESCRIPTION
Signed-off-by: Kharude, Sachin <sachin.kharude@here.com>
In order to make `xyzspaces` light weight removing `pandas` from dependency as it is only used to read the csv file.
made geobuf as optional as it is specific to only geospatial format.