### PR TITLE
Exclude tests submodules from package

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -7,7 +7,6 @@ include binder/*
 include xyzspaces/datasets/*
 include docs/notebooks/README.md docs/notebooks/*.ipynb
 include scripts/*
-include tests/hub/* tests/project/* tests/token/*
 include images/*
 exclude ort.yml
 include xyzspaces/config/logconfig.json

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ geo = ["geopandas", "turfpy>=0.0.3", "geobuf"]
 
 extras_require = {"dev": dev_reqs, "geo": geo}
 
-packages = find_packages(exclude=["docs", "tests"])
+packages = find_packages(exclude=["docs", "tests*"])
 
 version = {}
 with open('{}/__version__.py'.format(packages[0])) as f:


### PR DESCRIPTION
With current setup.py, pip install would still install "tests" package at the same level as xyzspaces package. Added wildcard pattern to exclude it